### PR TITLE
Remove reference to Elagabalus

### DIFF
--- a/public/gdb/index.md
+++ b/public/gdb/index.md
@@ -75,7 +75,7 @@ siblings:
 </blockquote></div>
 }!}
 
-For as long as human civilization has existed, [there have been people](https://en.wikipedia.org/wiki/Transgender_history) whose experience of their internal gender does not align with the physical features of their body. The Gala, a middle gender priest class of the Sumerian empire, exited over four thousand five hundred years ago. The indigenous cultures of North America recognized [a third gender](https://en.wikipedia.org/wiki/Third_gender) far before European colonialism, and still do to this day. Roman emperor Elagabalus (218 AD) insisted on being referred to as Lady rather than Lord, and even put forward a ransom for anyone who could conduct genital reconstruction surgery.
+For as long as human civilization has existed, [there have been people](https://en.wikipedia.org/wiki/Transgender_history) whose experience of their internal gender does not align with the physical features of their body. The Gala, a middle gender priest class of the Sumerian empire, exited over four thousand five hundred years ago. The indigenous cultures of North America recognized [a third gender](https://en.wikipedia.org/wiki/Third_gender) far before European colonialism, and still do to this day. 
 
 In spite of this, however, the modern understanding of the transgender experience is only approximately 130 years. Even the word "transgender" only dates back to 1965 when John Oliven proposed it as a more accurate alternative to David Cauldwell's term "transsexual" (coined in 1949), which itself replaced Magnus Hirschfield's term "transvestite" (1910).
 


### PR DESCRIPTION
Roman emperor Elagabalus is a poor historical representation for the trans community. Wikipedia here: https://en.wikipedia.org/wiki/Elagabalus

1. If Elagabalus was indeed trans, then the wikipedia article is misgendering
2. "Elagabalus developed a reputation among his contemporaries for extreme eccentricity, decadence, zealotry, and sexual promiscuity. This tradition has persisted, and among writers of the early modern age he suffered one of the worst reputations among Roman emperors"
3. "According to Barthold Georg Niebuhr, "the name Elagabalus is branded in history above all others" because of his "unspeakably disgusting life".[9] An example of a modern historian's assessment is Adrian Goldsworthy's: "Elagabalus was not a tyrant, but he was an incompetent, probably the least able emperor Rome had ever had."[10] "

While we can debate about if history is prejudice against Elagabalus (it most certainly is), we can all see that she is framed in such a negative light that using her to show trans people have been around for a long time is not helpful.