### PR TITLE
Navigation checking script

### DIFF
--- a/public/gdb/biochemical-dysphoria.md
+++ b/public/gdb/biochemical-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Biochemical Dysphoria"
+linkTitle: "Biochemical Dysphoria"
 description: "The very real and biological factors of Gender Dysphoria that cause mental disturbance."
 preBody: '_disclaimer'
 classes:

--- a/public/gdb/causes.md
+++ b/public/gdb/causes.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "What is the Cause of Gender Incongruence"
+linkTitle: "Causes of Gender Dysphoria"
 description: "It's the hormones, baby."
 preBody: '_disclaimer'
 classes:

--- a/public/gdb/chromosomes.md
+++ b/public/gdb/chromosomes.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "Disorders of Sex Development: Gender is not Chromosomal"
+linkTitle: "Chromosomes"
 description: "DNA is more what you'd call guidelines, than actual rules."
 preBody: '_disclaimer'
 classes:

--- a/public/gdb/conclusion.md
+++ b/public/gdb/conclusion.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "In Conclusion"
+linkTitle: "Conclusion"
 description: "Enough with the gatekeeping already."
 siblings:
   prev: /gdb/second-puberty-fem

--- a/public/gdb/diagnoses.md
+++ b/public/gdb/diagnoses.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "Diagnosing Gender Dysphoria"
+linkTitle: "Clinical Diagnoses"
 description: "It's clinical."
 preBody: '_disclaimer'
 classes:

--- a/public/gdb/euphoria.md
+++ b/public/gdb/euphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Euphoria"
+linkTitle: "Gender Euphoria"
 description: "In order for there to be shadow there must be light."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/historical-dysphoria.md
+++ b/public/gdb/historical-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Existential Dysphoria"
+linkTitle: "Existential Dysphoria"
 description: "I don't regret the things I have done, I regret the things I didn't do when I had the chance."
 classes:
   - gdb

--- a/public/gdb/history.md
+++ b/public/gdb/history.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "A Brief History of Gender Dysphoria"
+linkTitle: "The History of Gender Dysphoria"
 description: "The origins of Gender Dysphoria and the current meaning today."
 classes:
   - gdb

--- a/public/gdb/hormones.md
+++ b/public/gdb/hormones.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "Hormones: How do they work"
+linkTitle: "How Hormones Work"
 description: "It's nothing like magnets."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/impostor-syndrome.md
+++ b/public/gdb/impostor-syndrome.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "Impostor Syndrome, but make it Trans"
+linkTitle: "Impostor Syndrome"
 description: "Am I really trans?"
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/managed-dysphoria.md
+++ b/public/gdb/managed-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "Managed Dysphoria: Gender in Disguise"
+linkTitle: "Managed Dysphoria"
 description: "I don't regret the things I have done, I regret the things I didn't do when I had the chance."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/physical-dysphoria.md
+++ b/public/gdb/physical-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Physical Dysphoria"
+linkTitle: "Physical Dysphoria"
 description: "Body discomfort is only one of the many ways Gender Dysphoria manifests."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/presentational-dysphoria.md
+++ b/public/gdb/presentational-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Presentational Dysphoria"
+linkTitle: "Presentational Dysphoria"
 description: "Hoodies and sweatpants never go out of style."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/sexual-dysphoria.md
+++ b/public/gdb/sexual-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Sexual Dysphoria"
+linkTitle: "Sexual Dysphoria"
 description: "Sometimes a Cigar doesn't want to be smoked."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/social-dysphoria.md
+++ b/public/gdb/social-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Social Dysphoria"
+linkTitle: "Social Dysphoria"
 description: "Pronouns and Deadnames and Gendering, oh my."
 preBody: '_disclaimer'
 siblings:

--- a/public/gdb/societal-dysphoria.md
+++ b/public/gdb/societal-dysphoria.md
@@ -1,6 +1,7 @@
 ---
 date: "2020-01-26T20:41:55.827Z"
 title: "How Gender Dysphoria Manifests: Societal Dysphoria"
+linkTitle: "Societal Dysphoria"
 description: "Because a Role is a Role, and a Toll is a Toll, and it's a heavy toll to live the wrong role."
 preBody: '_disclaimer'
 siblings:

--- a/tools/navigation.py
+++ b/tools/navigation.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import os
+import glob
+import yaml
+
+
+def get_all_pages():
+  return [file for file in glob.glob("gdb/*.md")
+          if not file.endswith("/index.md")]
+
+
+def fix_web_path(page):
+  return '/' + page[:-3]
+
+
+def parse_page_data(page):
+  with open(page) as fd:
+    return next(yaml.safe_load_all(fd))
+
+
+def most_appropriate_title(data):
+  return data.get("linkTitle") or data['title']
+
+
+def traverse_siblings(pages, start, sibling='next'):
+  page = start
+  while page in pages:
+    yield page
+    page = pages[page]['siblings'].get(sibling)
+
+
+def create_intro_toc(pages, start, offset=2):
+  for num, page in enumerate(traverse_siblings(pages, start)):
+    data = pages[page]
+    title = most_appropriate_title(data)
+    print(f"{num + offset}. [{title}]({page})\n")
+
+
+def create_navbar(pages, start):
+  longest_link = max(map(len, traverse_siblings(pages, start))) + 2
+
+  for page in traverse_siblings(pages, start):
+    data = pages[page]
+    title = most_appropriate_title(data)
+    linksq = f"'{page}'"
+    linkdq = f'"{page}"'
+    print(f'    <a href={linkdq:{longest_link}s} class="{{{{#is meta.url {linksq:{longest_link}s}}}}}active {{{{/is}}}}dropdown-item">{title}</a>')
+
+
+def check_nav_consistency(pages, first):
+  for page in traverse_siblings(pages, first):
+    siblings = pages[page]['siblings']
+    for sibling in 'prev', 'next':
+      sibling_data = pages.get(siblings.get(sibling))
+      if sibling_data:
+        sibling_title = most_appropriate_title(sibling_data)
+        link_title = siblings[sibling + 'Caption']
+        if sibling_title != link_title:
+          print(f"{page}: caption mismatch for {sibling}: expected {sibling_title!r}, got {link_title!r}")
+
+
+def main():
+  os.chdir("../public")
+  pages = {fix_web_path(file): parse_page_data(file) for file in get_all_pages()}
+  *_, first = traverse_siblings(pages, next(iter(pages)), sibling="prev")
+  create_intro_toc(pages, first)
+  create_navbar(pages, first)
+  check_nav_consistency(pages, first)
+  return 0
+
+
+if __name__ == '__main__':
+  main()

--- a/tools/navigation.py
+++ b/tools/navigation.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-import os
 import glob
+import os
+import re
+import sys
 import yaml
 
 
@@ -29,14 +31,31 @@ def traverse_siblings(pages, start, sibling='next'):
     page = pages[page]['siblings'].get(sibling)
 
 
-def create_intro_toc(pages, start, offset=2):
+def create_intro_toc(pages, start, offset=2, file=sys.stdout):
   for num, page in enumerate(traverse_siblings(pages, start)):
     data = pages[page]
     title = most_appropriate_title(data)
-    print(f"{num + offset}. [{title}]({page})\n")
+    print(f"{num + offset}. [{title}]({page})\n", file=file)
 
 
-def create_navbar(pages, start):
+def overwrite_info_toc(pages, start, offset=2):
+  old_name = "gdb/index.md"
+  new_name = "gdb/.index.new"
+  with open(old_name) as orig:
+    with open(new_name, 'w') as new:
+      found = False
+      for line in orig:
+        if found and '</div' in line:
+          found = False
+          create_intro_toc(pages, start, offset=offset, file=new)
+        if not found and f'{offset}. [' in line:
+          found = True
+        if not found:
+          new.write(line)
+  os.rename(new_name, old_name)
+
+
+def create_navbar(pages, start, file=sys.stdout):
   longest_link = max(map(len, traverse_siblings(pages, start))) + 2
 
   for page in traverse_siblings(pages, start):
@@ -44,11 +63,28 @@ def create_navbar(pages, start):
     title = most_appropriate_title(data)
     linksq = f"'{page}'"
     linkdq = f'"{page}"'
-    print(f'    <a href={linkdq:{longest_link}s} class="{{{{#is meta.url {linksq:{longest_link}s}}}}}active {{{{/is}}}}dropdown-item">{title}</a>')
+    print(f'    <a href={linkdq:{longest_link}s} class="{{{{#is meta.url {linksq:{longest_link}s}}}}}active {{{{/is}}}}dropdown-item">{title}</a>', file=file)
 
 
-def check_nav_consistency(pages, first):
-  for page in traverse_siblings(pages, first):
+def overwrite_navbar(pages, start):
+  old_name = "_gdb-menu.hbs"
+  new_name = ".gdb-menu.new"
+  with open(old_name) as orig:
+    with open(new_name, 'w') as new:
+      found = False
+      for line in orig:
+        if found and '</div' in line:
+          found = False
+          create_navbar(pages, start, file=new)
+        if not found:
+          new.write(line)
+        if '="/gdb/"' in line:
+          found = True
+  os.rename(new_name, old_name)
+
+
+def check_nav_consistency(pages):
+  for page in pages:
     siblings = pages[page]['siblings']
     for sibling in 'prev', 'next':
       sibling_data = pages.get(siblings.get(sibling))
@@ -59,14 +95,48 @@ def check_nav_consistency(pages, first):
           print(f"{page}: caption mismatch for {sibling}: expected {sibling_title!r}, got {link_title!r}")
 
 
+def overwrite_nav_meta(pages):
+  for page in pages:
+    siblings = pages[page]['siblings']
+    old_name = page.lstrip("/") + '.md'
+    new_name = ".new.md"
+    with open(old_name) as orig:
+      with open(new_name, "w") as new:
+        for line in orig:
+          match = None
+          for sibling in 'prev', 'next':
+            sibling_data = pages.get(siblings.get(sibling))
+            if sibling_data:
+              sibling_title = most_appropriate_title(sibling_data)
+              match = re.match(f"( *{sibling}Caption: *).*", line)
+              if match:
+                new.write(match.group(1) + sibling_title + "\n")
+                break
+          if not match:
+            new.write(line)
+
+    os.rename(new_name, old_name)
+
+
+def check_excluded_pages(pages, first):
+  missing = set(pages.keys()) - set(traverse_siblings(pages, first))
+  if missing:
+    print(f"Unlinked pages (starting from {first}): {missing}")
+
+
 def main():
   os.chdir("../public")
   pages = {fix_web_path(file): parse_page_data(file) for file in get_all_pages()}
   *_, first = traverse_siblings(pages, next(iter(pages)), sibling="prev")
-  create_intro_toc(pages, first)
-  create_navbar(pages, first)
-  check_nav_consistency(pages, first)
-  return 0
+  check_excluded_pages(pages, first)
+  if '--write' in sys.argv:
+    overwrite_info_toc(pages, first)
+    overwrite_navbar(pages, first)
+    overwrite_nav_meta(pages)
+  else:
+    create_intro_toc(pages, first)
+    create_navbar(pages, first)
+    check_nav_consistency(pages)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A little maintenance script (about a 7 out of 10 on the hacky-o-meter) to keep the navigation in the dropdown, the `index.md` ToC, and the prev/next buttons consistent.

It might be a little overkill, I'm not sure. It uncovers some inconsistencies like `/gdb/causes`'s "next" button saying `But... but... the chromosomes!`, and `/gdb/hormones`'s "prev" button saying `Chromosomes`. It wants to overwrite many of the prev/next links though, because they aren't the same as the usual navigation text.

Usage: `cd tools && ./navigation.py` to just check, or `cd tools && ./navigation.py --write` to write changes to each file. (Changes can then be picked out with `git add -p` or similar)

Requires python 3 and libyaml for python (usually called `python-yaml` or `python3-yaml` in whatever package manager you use). 