### PR TITLE
Update and fix social media links

### DIFF
--- a/public/contributing.md
+++ b/public/contributing.md
@@ -28,9 +28,9 @@ The best way to add completely new content to the site is to reach out to me dir
 
 - [GitHub Repository](https://github.com/GenderDysphoria/GenderDysphoria.fyi)
 - Email Address: [gdb@curvyandtrans.com](mailto:gdb@curvyandtrans.com)
-- Twitter: [TwippingVanilla](http://twitter.com/twippingvanilla)
-- Instagram: [CurvyAndTrans](http://instagram/curvyandtrans)
-- Facebook: [Curvy and Trans](http://facebook.com/curvyandtrans)
+- Twitter: [Twippedtronic](https://twitter.com/twippedtronic)
+- Instagram: [CurvyAndTrans](https://instagram.com/curvyandtrans)
+- Facebook: [Curvy and Trans](https://facebook.com/curvyandtrans)
 - [Patreon](https://patreon.com/curvyandtrans)
 
 ## How to Contribute a Translation

--- a/public/tweets/index.html
+++ b/public/tweets/index.html
@@ -24,7 +24,7 @@ description: "A collection of the best twitter threads on transgender and gender
   <div class="disclaimer"><div class="container" style="text-align: center">
     <h1>Trans Twitter Topics</h1>
     <strong>A collection of the best Twitter threads on transgender and gender dysphoria topics.</strong>
-    <p>Have a thread that you think belongs here? <a href="https://twitter.com/TwippingVanilla">Send it my way</a>.</p>
+    <p>Have a thread that you think belongs here? <a href="https://twitter.com/Twippedtronic">Send it my way</a>.</p>
   </div></div>
   {{/content}}
 

--- a/templates/post.hbs
+++ b/templates/post.hbs
@@ -24,7 +24,7 @@
   <div class="disclaimer"><div class="container" style="text-align: center">
     <h1>Trans Twitter Topics</h1>
     <strong>A collection of the best Twitter threads on transgender and gender dysphoria topics.</strong>
-    <p>Have a thread that you think belongs here? <a href="https://twitter.com/TwippingVanilla">Send it my way</a>.</p>
+    <p>Have a thread that you think belongs here? <a href="https://twitter.com/Twippedtronic">Send it my way</a>.</p>
   </div></div>
   <article>
     <div class="post-head">


### PR DESCRIPTION
- Twitter/TwippingVanilla changed to @Twippedtronic
- Instagram link added TLD
- Instagram, Facebook, and Twitter links HTTPS‐ified

Direct links to tweets have not been touched, since I am unsure how the site handles those. E.g., it seems like some tweets are archived or otherwise saved directly in the source.