### PR TITLE
Added way for translation links to be page-specific

### DIFF
--- a/build/engines.js
+++ b/build/engines.js
@@ -16,6 +16,20 @@ const i18n = require('./lang');
 
 const mAnchor = require('markdown-it-anchor');
 
+// Process translation links (so /en/what-is-gender maps to /pt/que-e-gênero)
+const translationLinksRaw = require('../translation-links.json');
+const translationLinksMap = {};
+for (const group of translationLinksRaw) {
+  for (const [lang, url] of Object.entries(group)) {
+    if (url in translationLinksMap) {
+      console.log("URL '"+url+"' appears repeatedly on translation-links.json");
+      process.exit(1);
+    } else {
+      translationLinksMap[url] = group;
+    }
+  }
+}
+
 const markdownEngines = {
   full: markdownIt({
     html: true,
@@ -181,12 +195,13 @@ class Injectables {
 
   helpers () {
     return {
-      import:   this.import(),
-      markdown: this.markdown(),
-      icon:     this.icon(),
-      prod:     this.production(),
-      rev:      this.rev(),
-      lang:     this.lang(),
+      import:    this.import(),
+      markdown:  this.markdown(),
+      icon:      this.icon(),
+      translink: this.translink(),
+      prod:      this.production(),
+      rev:       this.rev(),
+      lang:      this.lang(),
     };
   }
 
@@ -281,4 +296,30 @@ class Injectables {
     };
   }
 
+  // Find the translation links for the current page from the file translation-links.json
+  //
+  // If a single argument is present, a single string will be returned, otherwise an
+  // object with links for all languages will be returned
+  // 
+  // Usage: {{translink new-lang fallback-url}}
+  translink () {
+    return function (...raw_args) {
+      let { resolve: rval, arguments: args } = raw_args.pop();
+      args.push(undefined, undefined);
+      const lang = args[0];
+      const fallback = args[1];
+      const page_url = rval('@root.this.url').trim();
+
+      let ans = translationLinksMap[page_url] || {};
+      if (lang !== undefined) {
+        ans = ans[lang];
+      }
+
+      if (ans === undefined) {
+        ans = fallback;
+      }
+
+      return ans;
+    };
+  }
 }

--- a/build/engines.js
+++ b/build/engines.js
@@ -202,6 +202,7 @@ class Injectables {
       prod:      this.production(),
       rev:       this.rev(),
       lang:      this.lang(),
+      lang2:      this.lang2()
     };
   }
 
@@ -288,10 +289,19 @@ class Injectables {
     };
   }
 
+  // Usage {{lang 'MY-STRING'}}
   lang () {
     return function (key, ...args) {
       const { resolve: rval } = args.pop();
       const lang = rval('@root.this.page.lang').split('-')[0];
+      return i18n(lang, key, ...args);
+    };
+  }
+
+  // Usage {{lang2 other-lang 'MY-STRING'}}
+  lang2 () {
+    return function (lang, key, ...args) {
+      const { resolve: rval } = args.pop();
       return i18n(lang, key, ...args);
     };
   }

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -49,6 +49,7 @@ exports.testpush = pushToProd.dryrun;
 function watcher () {
 
   watch([
+    'translation-links.json'
     'public/**/*.{md,hbs,html}',
     'posts/**/*.{md,hbs,html}',
     'templates/*.{md,hbs,html}',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "title": "That's Gender Dysphoria, FYI",
     "domain": "genderdysphoria.fyi",
     "lang": "en",
+    "allLangs": ["en", "zh", "fr", "de", "hu", "pl"],
     "siteUrl": "https://genderdysphoria.fyi",
     "description": "A resource for those questioning their gender, already on a gender journey, or simply wanting to learn more about what it is to be transgender.",
     "creator": "TwippingVanilla",

--- a/public/de/_strings.js
+++ b/public/de/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'Deutsch (DE)',
+  MENU_LANGUAGE_LONG: 'Deutsch (German)',
   SITE_TITLE: 'Das ist Gender Dysphorie',
-  SITE_DESCRIPTION: 'Eine Informationsquelle für all jene, die ihr Geschlecht in Frage stellen, schon auf Ihrer persönlichen gender-Reise sind oder einfach mehr darüber lernen möchten was es bedeutet Transgender zu sein.',
-  
   HEADER_TITLE: '<abbr title="Zu Ihrer Information">FYI</abbr>, das ist Gender Dysphorie',
+  SITE_DESCRIPTION: 'Eine Informationsquelle für all jene, die ihr Geschlecht in Frage stellen, schon auf Ihrer persönlichen gender-Reise sind oder einfach mehr darüber lernen möchten was es bedeutet Transgender zu sein.',
+
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'HH:mm - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+  
   PATREON_FOOTER_BODY: 'Diese Seite wurde dank der Unterstützung der Community ermöglicht. Wenn Ihnen diese Seite geholfen hat dann können Sie <a href="https://www.patreon.com/curvyandtrans">via Patreon</a> oder <a href="https://ko-fi.com/curvyandtrans">Ko-fi</a> Spenden.',
   PATREON_FOOTER_THANKS: 'Ein besonderes Dankeschön geht an folgende Patreon Unterstützer:',
   FOOTER_COPYRIGHT: 'Dieser Text, der Website-Code und die ursprünglichen Bilder sind <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/"> lizensiert unter CC BY-NC-SA.</a>',
   FOOTER_COPYRIGHT2: 'und anderen',
-
-  'TRANS_TWITTER_TOPICS': 'Trans Twitter Topics',
-
-  MENU_LANGUAGE: 'Deutsch (DE)',
 };
 

--- a/public/en/_strings.js
+++ b/public/en/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'English (EN)',
+  MENU_LANGUAGE_LONG: 'English (EN)',
   SITE_TITLE: 'That\'s Gender Dysphoria, FYI',
+  HEADER_TITLE: 'That\'s Gender Dysphoria, <abbr title="For Your Information">FYI</abbr>',
   SITE_DESCRIPTION: 'A resource for those questioning their gender, already on a gender journey, or simply wanting to learn more about what it is to be transgender.',
 
-  HEADER_TITLE: 'That\'s Gender Dysphoria, <abbr title="For Your Information">FYI</abbr>',
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'h:mm aa - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+
   PATREON_FOOTER_BODY: 'This site is made possible thanks to contributions from the community. If you have found this site invaluable, please consider <a href="https://www.patreon.com/curvyandtrans">making a pledge on patreon</a> or a <a href="https://ko-fi.com/curvyandtrans">donation via Ko-fi</a>.',
   PATREON_FOOTER_THANKS: 'Special thanks to the following patreon supporters:',
   FOOTER_COPYRIGHT: 'Site text, website code and original graphics are <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">licensed CC BY-NC-SA.</a>',
-  FOOTER_COPYRIGHT2: 'and Other Contributors',
-
-  'TRANS_TWITTER_TOPICS': 'Trans Twitter Topics',
-
-  MENU_LANGUAGE: 'English (EN)',
+  FOOTER_COPYRIGHT2: 'and Other Contributors'
 };
 

--- a/public/es/_strings.js
+++ b/public/es/_strings.js
@@ -1,9 +1,20 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'Español (ES)',
+  MENU_LANGUAGE_LONG: 'Español (Spanish)',
   SITE_TITLE: 'Eso es Disforia de Género, PSI',
-
   HEADER_TITLE: 'Eso es Disforia de Género, <abbr title="Para Su Información">PSI</abbr>',
+  SITE_DESCRIPTION: 'Un recurso para aquellos que cuestionan su género, o que ya están en un viaje de género o simplemente quieren aprender más sobre lo que es ser transgénero.',
+  'TRANS_TWITTER_TOPICS': 'Temas Trans en Twitter',
 
-  MENU_LANGUAGE: 'Español (ES)',
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'HH:mm aa - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+
+  PATREON_FOOTER_BODY: 'This site is made possible thanks to contributions from the community. If you have found this site invaluable, please consider <a href="https://www.patreon.com/curvyandtrans">making a pledge on patreon</a> or a <a href="https://ko-fi.com/curvyandtrans">donation via Ko-fi</a>.',
+  PATREON_FOOTER_THANKS: 'Special thanks to the following patreon supporters:',
+  FOOTER_COPYRIGHT: 'Site text, website code and original graphics are <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">licensed CC BY-NC-SA.</a>',
+  FOOTER_COPYRIGHT2: 'and Other Contributors'
 };
 

--- a/public/fr/_strings.js
+++ b/public/fr/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'Français (FR)',
+  MENU_LANGUAGE_LONG: 'Français (French)',
   SITE_TITLE: 'C\'est la dysphorie de genre, pour info',
+  HEADER_TITLE: 'C\'est la dysphorie de genre, pour info',
   SITE_DESCRIPTION: 'Une ressource pour les personnes qui s\'interrogent sur leur genre, qui sont déjà engagées dans un parcours de changement de genre ou qui veulent simplement en savoir plus sur ce que c\'est que d\'être transgenre.',
 
-  HEADER_TITLE: 'C\'est la dysphorie de genre, pour info',
+  TRANS_TWITTER_TOPICS: 'Topics de Trans Twitter',
+  TWEET_DATE_FORMAT: 'HH:mm - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+
   PATREON_FOOTER_BODY: 'Ce site est rendu possible grâce aux contributions de la communauté. Si tu as trouvé ce site inestimable, pense à <a href="https://www.patreon.com/curvyandtrans">faire un don sur patreon</a> ou un <a href="https://ko-fi.com/curvyandtrans">don via Ko-fi</a>.',
   PATREON_FOOTER_THANKS: 'Nous remercions tout particulièrement les supporters patreon suivants :',
   FOOTER_COPYRIGHT: 'Le texte du site, le code du site et les graphiques originaux sont <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">sous license CC BY-NC-SA.</a>',
   FOOTER_COPYRIGHT2: 'et autres contributeurs',
-
-  'TRANS_TWITTER_TOPICS': 'Topics de Trans Twitter',
-
-  MENU_LANGUAGE: 'Français (FR)',
 };
 

--- a/public/hu/_strings.js
+++ b/public/hu/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'Magyar (HU)',
+  MENU_LANGUAGE_LONG: 'Magyar (Hungarian)',
   SITE_TITLE: 'Ez a Gender Diszfória, FYI',
+  HEADER_TITLE: 'Ez a Gender Diszfória, <abbr title="Csak, hogy tudd">FYI</abbr>',
   SITE_DESCRIPTION: 'Forrás azoknak, akik megkérdőjelezik a nemüket, akik már elindultak a saját útjukon, vagy egyszerűen csak többet szeretnének megtudni arról, hogy mit jelent transzneműnek lenni.',
 
-  HEADER_TITLE: 'Ez a Gender Diszfória, <abbr title="Csak, hogy tudd">FYI</abbr>',
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'HH:mm - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+  
   PATREON_FOOTER_BODY: 'Ez az oldal a közösség hozzájárulásának köszönhetően jött létre. Ha felbecsülhetetlen értékűnek találod ezt az oldalt, kérjük, hogy <a href="https://www.patreon.com/curvyandtrans">támogass a patreonon</a> vagy <a href="https://ko-fi.com/curvyandtrans">Ko-fin keresztül</a>.',
   PATREON_FOOTER_THANKS: 'Külön köszönet Patreon támogatóinknak, különösen nekik:',
   FOOTER_COPYRIGHT: 'Az oldal szövege, a weboldal kódja és az eredeti grafikák <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">CC BY-NC-SA alatt licenszeltek.</a>',
   FOOTER_COPYRIGHT2: 'és más közreműködők',
-
-  'TRANS_TWITTER_TOPICS': 'Trans Twitter Topics',
-
-  MENU_LANGUAGE: 'Magyar (HU)',
 };
 

--- a/public/pl/_strings.js
+++ b/public/pl/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: 'polski (PL)',
+  MENU_LANGUAGE_LONG: 'polski (Polish)',
   SITE_TITLE: 'To dysforia płciowa, FYI',
+  HEADER_TITLE: 'To dysforia płciowa, <abbr title="dla twojej informacji">FYI</abbr>',
   SITE_DESCRIPTION: 'Źródło wiedzy dla kwestionujących swoją tożsamość płciową, tych w trakcie płciowej podróży, jak i tych, którzy po prostu chcą się dowiedzieć, czym jest transpłciowość.',
 
-  HEADER_TITLE: 'To dysforia płciowa, <abbr title="dla twojej informacji">FYI</abbr>',
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'HH:mm - EEE, LLL do, yyyy',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+  
   PATREON_FOOTER_BODY: 'Ta strona istnieje dzięki społeczności. Jeśli jest dla ciebie nieoceniona, rozważ <a href="https://www.patreon.com/curvyandtrans">wsparcie na patreonie</a> bądź <a href="https://ko-fi.com/curvyandtrans">donację poprzez Ko-fi</a>.',
   PATREON_FOOTER_THANKS: 'Szczególne podziękowania dla następujących patronów:',
   FOOTER_COPYRIGHT: 'Tekst i kod strony, jak również oryginalne grafiki są <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">licencjonowane CC BY-NC-SA.</a>',
   FOOTER_COPYRIGHT2: 'i inni współautorzy',
-
-  'TRANS_TWITTER_TOPICS': 'Trans Twitter Topics',
-
-  MENU_LANGUAGE: 'polski (PL)',
 };
 

--- a/public/zh/_strings.js
+++ b/public/zh/_strings.js
@@ -1,16 +1,19 @@
 
 module.exports = exports = {
+  MENU_LANGUAGE_SHORT: '中文 (ZH)',
+  MENU_LANGUAGE_LONG: '中文 (Chinese)',
   SITE_TITLE: '这就是性别烦躁，供参考',
+  HEADER_TITLE: '这就是性别烦躁，供参考',
   SITE_DESCRIPTION: '为那些正在质疑探索中的人、那些在跨性别道路上的人和单纯想成为盟友的人提供资源。',
 
-  HEADER_TITLE: '这就是性别烦躁，<abbr title="供参考">供参考</abbr>',
+  TRANS_TWITTER_TOPICS: 'Trans Twitter Topics',
+  TWEET_DATE_FORMAT: 'yyyy年MM月dd日周三 下午hh:mm',
+  MISSING_TWEET_FOR: 'Missing tweet for ',
+  QUOTED_TWEET_UNAVAILABLE: 'Quoted Tweet Unavailable',
+
   PATREON_FOOTER_BODY: 'This site is made possible thanks to contributions from the community. If you have found this site invaluable, please consider <a href="https://www.patreon.com/curvyandtrans">making a pledge on patreon</a> or a <a href="https://ko-fi.com/curvyandtrans">donation via Ko-fi</a>.',
   PATREON_FOOTER_THANKS: 'Special thanks to the following patreon supporters:',
   FOOTER_COPYRIGHT: 'Site text, website code and original graphics are <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/">licensed CC BY-NC-SA.</a>',
-  FOOTER_COPYRIGHT2: 'and Other Contributors',
-
-  'TRANS_TWITTER_TOPICS': 'Trans Twitter Topics',
-
-  MENU_LANGUAGE: '中文 (ZH)',
+  FOOTER_COPYRIGHT2: 'and Other Contributors'
 };
 

--- a/templates/language-menu.hbs
+++ b/templates/language-menu.hbs
@@ -1,8 +1,5 @@
 <div class="dropdown-menu" aria-labelledby="nav-gdb">
-  <a href="{{translink 'en' '/en/'}}" class="{{#is page.lang 'en'}}active {{/is}}dropdown-item">English</a>
-  <a href="{{translink 'zh' '/zh/'}}" class="{{#is page.lang 'zh'}}active {{/is}}dropdown-item">中文 (Chinese)</a>
-  <a href="{{translink 'fr' '/fr/'}}" class="{{#is page.lang 'fr'}}active {{/is}}dropdown-item">Français (French)</a>
-  <a href="{{translink 'de' '/de/'}}" class="{{#is page.lang 'de'}}active {{/is}}dropdown-item">Deutsch (German)</a>
-  <a href="{{translink 'hu' '/hu/'}}" class="{{#is page.lang 'hu'}}active {{/is}}dropdown-item">Magyar (Hungarian)</a>
-  <a href="{{translink 'pl' '/pl/'}}" class="{{#is page.lang 'pl'}}active {{/is}}dropdown-item">polski (Polish)</a>
+  {{#each site.allLangs}}
+    <a href="/{{this}}/" class="{{#is page.lang this}}active {{/is}}dropdown-item">{{lang2 this 'MENU_LANGUAGE_LONG'}}</a>
+  {{/each}}
 </div>

--- a/templates/language-menu.hbs
+++ b/templates/language-menu.hbs
@@ -1,8 +1,8 @@
 <div class="dropdown-menu" aria-labelledby="nav-gdb">
-  <a href="/en/" class="{{#is page.lang 'en'}}active {{/is}}dropdown-item">English</a>
-  <a href="/zh/" class="{{#is page.lang 'zh'}}active {{/is}}dropdown-item">中文 (Chinese)</a>
-  <a href="/fr/" class="{{#is page.lang 'fr'}}active {{/is}}dropdown-item">Français (French)</a>
-  <a href="/de/" class="{{#is page.lang 'de'}}active {{/is}}dropdown-item">Deutsch (German)</a>
-  <a href="/hu/" class="{{#is page.lang 'hu'}}active {{/is}}dropdown-item">Magyar (Hungarian)</a>
-  <a href="/pl/" class="{{#is page.lang 'pl'}}active {{/is}}dropdown-item">polski (Polish)</a>
+  <a href="{{translink 'en' '/en/'}}" class="{{#is page.lang 'en'}}active {{/is}}dropdown-item">English</a>
+  <a href="{{translink 'zh' '/zh/'}}" class="{{#is page.lang 'zh'}}active {{/is}}dropdown-item">中文 (Chinese)</a>
+  <a href="{{translink 'fr' '/fr/'}}" class="{{#is page.lang 'fr'}}active {{/is}}dropdown-item">Français (French)</a>
+  <a href="{{translink 'de' '/de/'}}" class="{{#is page.lang 'de'}}active {{/is}}dropdown-item">Deutsch (German)</a>
+  <a href="{{translink 'hu' '/hu/'}}" class="{{#is page.lang 'hu'}}active {{/is}}dropdown-item">Magyar (Hungarian)</a>
+  <a href="{{translink 'pl' '/pl/'}}" class="{{#is page.lang 'pl'}}active {{/is}}dropdown-item">polski (Polish)</a>
 </div>

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -65,7 +65,7 @@
           <ul class="top-nav-inner">
             <li>{{import (join [ '/public/' page.lang '/_menu' ] "")}}</li>
             <li>
-              <a href="/en/" class="top-nav-item dropdown-toggle" id="nav-lang" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="false">{{lang 'MENU_LANGUAGE'}}</a>
+              <a href="#" class="top-nav-item dropdown-toggle" id="nav-lang" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="false">{{lang 'MENU_LANGUAGE_SHORT'}}</a>
               {{import "~/language-menu"}}
             </li>
             <li><a href="/tweets/" class="top-nav-item" title="{{{lang 'TRANS_TWITTER_TOPICS'}}}"><img src="/images/transtwitter.png" width="24" height="24" alt=""></a></li>

--- a/translation-links.json
+++ b/translation-links.json
@@ -1,0 +1,90 @@
+[
+	{
+		"en": "/en",
+		"zh": "/zh"
+	},
+	{
+		"en": "/en/what-is-gender",
+		"zh": "/zh/什么是性别"
+	},
+	{
+		"en": "/en/history",
+		"zh": "/zh/历史"
+	},
+	{
+		"en": "/en/euphoria",
+		"zh": "/zh/亢奋"
+	},
+	{
+		"en": "/en/physical-dysphoria",
+		"zh": "/zh/身体烦躁"
+	},
+	{
+		"en": "/en/biochemical-dysphoria",
+		"zh": "/zh/生化烦躁"
+	},
+	{
+		"en": "/en/social-dysphoria",
+		"zh": "/zh/社交烦躁"
+	},
+	{
+		"en": "/en/societal-dysphoria",
+		"zh": "/zh/社会烦躁"
+	},
+	{
+		"en": "/en/sexual-dysphoria",
+		"zh": "/zh/性烦躁"
+	},
+	{
+		"en": "/en/presentational-dysphoria",
+		"zh": "/zh/外表烦躁"
+	},
+	{
+		"en": "/en/existential-dysphoria",
+		"zh": "/zh/存在烦躁"
+	},
+	{
+		"en": "/en/managed-dysphoria",
+		"zh": "/zh/掌控烦躁"
+	},
+	{
+		"en": "/en/impostor-syndrome",
+		"zh": "/zh/冒名顶替综合征"
+	},
+	{
+		"en": "/en/diagnoses",
+		"zh": "/zh/诊断"
+	},
+	{
+		"en": "/en/treatment",
+		"zh": "/zh/治疗"
+	},
+	{
+		"en": "/en/causes",
+		"zh": "/zh/成因"
+	},
+	{
+		"en": "/en/chromosomes",
+		"zh": "/zh/染色体"
+	},
+	{
+		"en": "/en/hormones",
+		"zh": "/zh/激素"
+	},
+	{
+		"en": "/en/second-puberty-masc",
+		"zh": "/zh/雄二青春期"
+	},
+	{
+		"en": "/en/second-puberty-fem",
+		"zh": "/zh/雌二青春期"
+	},
+	{
+		"en": "/en/conclusion",
+		"zh": "/zh/结语"
+	},
+	{
+		"en": "/en/printable",
+		"zh": "/zh/printable"
+	}
+]


### PR DESCRIPTION
Added file `translation-links.json` which specifies equivalent pages across translations.

So a page like `/en/what-is-gender` can send the user to `/es/que-es-genero` when the user clicks on the Spanish language link.