### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  node_app:
+    image: node:18
+    platform: linux/amd64
+    working_dir: /app
+    volumes:
+      - ./:/app
+      - ./node_modules:/app/node_modules
+      - ./dist:/app/dist
+    command: ["sh", "-c", "npm install && npm run build"]


### PR DESCRIPTION
I have an Apple Silicon mac and it doesn't build the website even when I have Node.js 18. Turns out, there seem to be some dependency issues.

So I added a docker-compose.yml. This way, I can simply run `docker-compose up` and build the website.