### PR TITLE
fix: add lang front matter to fix broken nav bar

### DIFF
--- a/public/es/disforia-existencial.md
+++ b/public/es/disforia-existencial.md
@@ -6,6 +6,7 @@ description: "No me arrepiento de las cosas que he hecho, me arrepiento de las c
 classes:
   - gdb
 preBody: '_declaracion'
+lang: es
 siblings:
   prev: /es/disforia-de-presentacion
   prevCaption: Disforia De Presentacion

--- a/public/es/hormonas.md
+++ b/public/es/hormonas.md
@@ -4,6 +4,7 @@ title: "Las hormonas: Cómo funcionan"
 linkTitle: "Cómo funcionan las hormonas"
 description: "No es nada parecido a los imanes."
 preBody: '_declaracion'
+lang: es
 siblings:
   prev: /es/cromosomas
   prevCaption: Cromosomas

--- a/public/zh/亢奋.md
+++ b/public/zh/亢奋.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：性别亢奋"
 linkTitle: "性别亢奋"
 description: "有阴影，那就必须有光。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/历史
   prevCaption: 性别烦躁简史

--- a/public/zh/什么是性别.md
+++ b/public/zh/什么是性别.md
@@ -3,6 +3,7 @@ date: "2020-01-26T20:41:55.827Z"
 title: "什么是性别？"
 description: "如何定义性别，它又如何与生理性别区分？"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/
   prevCaption: 简介

--- a/public/zh/冒名顶替综合征.md
+++ b/public/zh/冒名顶替综合征.md
@@ -4,6 +4,7 @@ title: "冒名顶替综合征，但要成为跨儿"
 linkTitle: "冒名顶替综合征"
 description: "我是真正的跨儿吗？"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/掌控烦躁
   prevCaption: 掌控烦躁

--- a/public/zh/历史.md
+++ b/public/zh/历史.md
@@ -6,6 +6,7 @@ description: "性别烦躁的起源和当代含义。"
 classes:
   - gdb
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/什么是性别
   prevCaption: 什么是性别？

--- a/public/zh/外表烦躁.md
+++ b/public/zh/外表烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：外表烦躁"
 linkTitle: "外表烦躁"
 description: "卫衣和运动裤永远不过时。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/性烦躁
   prevCaption: 性烦躁

--- a/public/zh/存在烦躁.md
+++ b/public/zh/存在烦躁.md
@@ -6,6 +6,7 @@ description: "我不后悔我做过的事，我后悔本有机会却没做的事
 classes:
   - gdb
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/外表烦躁
   prevCaption: 外表烦躁

--- a/public/zh/性烦躁.md
+++ b/public/zh/性烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：性烦躁"
 linkTitle: "性烦躁"
 description: "有时候雪茄不想被抽。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/社会烦躁
   prevCaption: 社会烦躁

--- a/public/zh/成因.md
+++ b/public/zh/成因.md
@@ -4,6 +4,7 @@ title: "性别不一致的成因是什么"
 linkTitle: "性别不一致的成因"
 description: "宝贝，是激素啊。"
 preBody: '_disclaimer'
+lang: zh
 classes:
   - gdb
 tweets:

--- a/public/zh/我是跨性别吗.md
+++ b/public/zh/我是跨性别吗.md
@@ -11,6 +11,7 @@ siblings:
 classes:
   - gdb
 preBody: '_disclaimer'
+lang: zh
 
 ---
 

--- a/public/zh/掌控烦躁.md
+++ b/public/zh/掌控烦躁.md
@@ -4,6 +4,7 @@ title: "掌控烦躁：掩饰性别"
 linkTitle: "掌控烦躁"
 description: "我不后悔我做过的事，我后悔本有机会却没做的事。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/存在烦躁
   prevCaption: 存在烦躁

--- a/public/zh/染色体.md
+++ b/public/zh/染色体.md
@@ -4,6 +4,7 @@ title: "性发育异常：性别不是染色体"
 linkTitle: "Chromosomes"
 description: "DNA 更像是指导方针，而不是实际规则。"
 preBody: '_disclaimer'
+lang: zh
 classes:
   - gdb
 siblings:

--- a/public/zh/治疗.md
+++ b/public/zh/治疗.md
@@ -3,6 +3,7 @@ date: "2020-01-26T20:41:55.827Z"
 title: "治疗性别烦躁"
 description: "转变就是治愈之法。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/诊断
   prevCaption: 临床诊断

--- a/public/zh/激素.md
+++ b/public/zh/激素.md
@@ -4,6 +4,7 @@ title: "激素：它们是如何起作用的"
 linkTitle: "激素的作用"
 description: "它不像是磁铁。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/染色体
   prevCaption: 染色体

--- a/public/zh/生化烦躁.md
+++ b/public/zh/生化烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：生化烦躁"
 linkTitle: "生化烦躁"
 description: "引发心理问题的性别烦躁生物因素。"
 preBody: '_disclaimer'
+lang: zh
 classes:
   - gdb
 tweets:

--- a/public/zh/社交烦躁.md
+++ b/public/zh/社交烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：社交烦躁"
 linkTitle: "社交烦躁"
 description: "人称代词、转变前的旧名字和区分性别，哦天哪。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/生化烦躁
   prevCaption: 生化烦躁

--- a/public/zh/社会烦躁.md
+++ b/public/zh/社会烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：社会烦躁"
 linkTitle: "社会烦躁"
 description: "因为角色就是角色，代价就是代价，扮演错误的角色是沉重的代价。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/社交烦躁
   prevCaption: 社交烦躁

--- a/public/zh/结语.md
+++ b/public/zh/结语.md
@@ -9,6 +9,7 @@ siblings:
 classes:
   - gdb
 preBody: '_disclaimer'
+lang: zh
 ---
 
 ## 结语

--- a/public/zh/诊断.md
+++ b/public/zh/诊断.md
@@ -4,6 +4,7 @@ title: "诊断性别烦躁"
 linkTitle: "临床诊断"
 description: "这是临床的。"
 preBody: '_disclaimer'
+lang: zh
 classes:
   - gdb
 siblings:

--- a/public/zh/身体烦躁.md
+++ b/public/zh/身体烦躁.md
@@ -4,6 +4,7 @@ title: "性别烦躁是如何表现的：身体烦躁"
 linkTitle: "身体烦躁"
 description: "身体的不适是性别烦躁的诸多表现形式之一。"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/亢奋
   prevCaption: 性别亢奋

--- a/public/zh/雄二青春期.md
+++ b/public/zh/雄二青春期.md
@@ -4,6 +4,7 @@ title: "“雄性激素诱导的第二青春期”导论"
 linkTitle: 雄性激素青春期
 description: "能从男性化HRT中得到什么"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/激素
   prevCaption: 激素的作用

--- a/public/zh/雌二青春期.md
+++ b/public/zh/雌二青春期.md
@@ -4,6 +4,7 @@ title: "“雌性激素诱导的第二青春期”导论"
 linkTitle: 雌性激素青春期
 description: "能从女性化HRT中得到什么"
 preBody: '_disclaimer'
+lang: zh
 siblings:
   prev: /zh/雄二青春期
   prevCaption: 雄性激素第二青春期


### PR DESCRIPTION
This pull request adds explicit language metadata to multiple markdown files in both the Spanish (`es`) and Chinese (`zh`) content directories. The primary purpose is to include a `lang` field in the front matter of each file, which will help with localization and language-specific processing, such as the nav bar:

<img width="1174" height="363" src="https://github.com/user-attachments/assets/fb5e3f71-cd48-4c91-aae6-c8af3efc088a" />
